### PR TITLE
fix: do not run post-release on dry-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ jobs:
 
 ## Inputs
 
-| Name                   | Description                                                                                                                                                | Default   |
-| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
-| `develop_branch`       | Name of the develop branch                                                                                                                                 | `develop` |
-| `main_branch`          | Name of the main branch                                                                                                                                    | `main`    |
-| `merge_back_from_main` | If `"true"`, there will be a merge back from `main` instead of the release branch to `develop` after a release is created                                  | `"false"` |
-| `version`              | Version to release                                                                                                                                         |           |
-| `dry_run`              | If `"true"`, the action will not create any PRs or releases. It will only print out the steps it would take and some outputs like pull_numbers_in_release. | `"false"` |
-| `release_summary`      | Specify the release summary to be put in the last section of the release PR                                                                                | `""`      |
+| Name                   | Description                                                                                                                                                                                                                                                                | Default   |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| `develop_branch`       | Name of the develop branch                                                                                                                                                                                                                                                 | `develop` |
+| `main_branch`          | Name of the main branch                                                                                                                                                                                                                                                    | `main`    |
+| `merge_back_from_main` | If `"true"`, there will be a merge back from `main` instead of the release branch to `develop` after a release is created. See [this Stackoverflow discussion](https://stackoverflow.com/questions/46604715/gitflow-merging-release-bugfixes-back-to-develop-from-master). | `"false"` |
+| `version`              | Version to release                                                                                                                                                                                                                                                         |           |
+| `dry_run`              | If `"true"`, the action will not create any PRs or releases. It will only print out the steps it would take and some outputs like pull_numbers_in_release.                                                                                                                 | `"false"` |
+| `release_summary`      | Specify the release summary to be put in the last section of the release PR                                                                                                                                                                                                | `""`      |
 
 Alternatively, the following environment variables can be used: `DEVELOP_BRANCH`, `MAIN_BRANCH`, `MERGE_BACK_FROM_MAIN`, `VERSION`, `DRY_RUN`, `RELEASE_SUMMARY`.
 
@@ -148,8 +148,11 @@ jobs:
   release_workflow:
     runs-on: ubuntu-latest
     steps:
+      # This step is only run for `generate_pr_summary` step
+      # which is only run when the workflow is triggered from the "Run workflow" window
       - id: release_workflow_dry_run
         name: gitflow-workflow-action release workflows
+        if: github.event_name == 'workflow_dispatch'
         uses: hoangvvo/gitflow-workflow-action@<TAG>
         with:
           develop_branch: "develop"
@@ -192,7 +195,6 @@ jobs:
         with:
           develop_branch: "develop"
           main_branch: "main"
-          merge_back_from_main: false
           version: ${{ inputs.version }}
           release_summary: ${{ steps.generate_pr_summary.outputs.result }}
         env:

--- a/src/post-release.js
+++ b/src/post-release.js
@@ -10,6 +10,13 @@ import { isReleaseCandidate, tryMerge } from "./utils.js";
  * @returns {Promise<import("./types.js").Result>}
  */
 async function executeOnRelease() {
+  if (Config.isDryRun) {
+    console.log(`on-release: dry run. Exiting...`);
+    return {
+      type: "none",
+    };
+  }
+
   if (!github.context.payload.pull_request?.merged) {
     console.log(`on-release: pull request is not merged. Exiting...`);
     return {
@@ -62,7 +69,7 @@ async function executeOnRelease() {
     ).padStart(2, "0")}${String(now.getMinutes()).padStart(2, "0")}`;
   }
 
-  console.log(`on-release: release(${version}): Generating release notes`);
+  console.log(`on-release: release(${version}): Generating release`);
 
   const pullRequestBody = pullRequest.body;
 


### PR DESCRIPTION
This generates duplicate release if flowing the [Preview summary example](https://github.com/hoangvvo/gitflow-workflow-action#example-prefill-release-summary)

Fix #56