### PR TITLE
Bugfix: Support long PR descriptions

### DIFF
--- a/src/release.ts
+++ b/src/release.ts
@@ -2,7 +2,7 @@
 import semverInc from "semver/functions/inc.js";
 import { Config, octokit } from "./shared.js";
 import { Result } from "./types.js";
-import { createExplainComment } from "./utils.js";
+import { createExplainComment, truncatePrDescription } from "./utils.js";
 
 export async function createReleasePR(): Promise<Result> {
   const isDryRun = Config.isDryRun;
@@ -59,6 +59,9 @@ export async function createReleasePR(): Promise<Result> {
 ${Config.releaseSummary}
   `;
 
+  // Truncate the PR body if it exceeds GitHub's character limit
+  const truncatedReleasePrBody = truncatePrDescription(releasePrBody);
+
   const releaseBranch = `${Config.releaseBranchPrefix}${version}`;
   let pull_number;
 
@@ -77,7 +80,7 @@ ${Config.releaseSummary}
     const { data: pullRequest } = await octokit.rest.pulls.create({
       ...Config.repo,
       title: `Release ${releaseNotes.name || version}`,
-      body: releasePrBody,
+      body: truncatedReleasePrBody,
       head: releaseBranch,
       base: Config.prodBranch,
       maintainer_can_modify: false,
@@ -98,7 +101,7 @@ ${Config.releaseSummary}
     );
   } else {
     console.log(
-      `create_release: Dry run: would have created release branch ${releaseBranch} and PR with body:\n${releasePrBody}`,
+      `create_release: Dry run: would have created release branch ${releaseBranch} and PR with body:\n${truncatedReleasePrBody}`,
     );
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,8 @@ import { RestEndpointMethodTypes } from "@octokit/plugin-rest-endpoint-methods";
 import { PR_EXPLAIN_MESSAGE } from "./constants.js";
 import { Config, octokit } from "./shared.js";
 
+const GITHUB_PR_BODY_LIMIT = 65536;
+
 export async function tryMerge(headBranch: string, baseBranch: string) {
   console.log(
     `Trying to merge ${headBranch} branch into ${baseBranch} branch.`,
@@ -107,3 +109,22 @@ export async function createExplainComment(pullRequestNumber: number) {
 
 export const removeHtmlComments = (text: string) =>
   text.replace(/<!--.*?-->/gs, "");
+
+/**
+ * GitHub has a limit of 65,536 characters for PR descriptions.
+ * This function truncates the description if it exceeds the limit
+ * and appends "..." to indicate truncation.
+ */
+export function truncatePrDescription(description: string): string {  
+  if (description.length <= GITHUB_PR_BODY_LIMIT) {
+    return description;
+  }
+  
+  console.log(
+    `PR description is ${description.length} characters, which exceeds GitHub's limit of ${GITHUB_PR_BODY_LIMIT}. Truncating to fit.`
+  );
+  
+  // Reserve 3 characters for the "..." suffix
+  const truncatedLength = GITHUB_PR_BODY_LIMIT - 3;
+  return description.substring(0, truncatedLength) + "...";
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import { RestEndpointMethodTypes } from "@octokit/plugin-rest-endpoint-methods";
 import { PR_EXPLAIN_MESSAGE } from "./constants.js";
 import { Config, octokit } from "./shared.js";
 
-const GITHUB_PR_BODY_LIMIT = 65536;
+const GITHUB_PR_BODY_LIMIT = 65000;
 
 export async function tryMerge(headBranch: string, baseBranch: string) {
   console.log(


### PR DESCRIPTION
This PR adds support for long PR descriptions which would otherwise be rejected by GitHub. If a PR description is too long, it is truncated and `...` is appended.